### PR TITLE
Add more options in config

### DIFF
--- a/src/amae-koromo/utils/conf.ts
+++ b/src/amae-koromo/utils/conf.ts
@@ -1,5 +1,6 @@
 import { GameMode } from "../types/index.js";
 import dayjs from "dayjs";
+import config from "../../config.js";
 
 export const CONFIGURATIONS = {
     DEFAULT: {
@@ -166,7 +167,7 @@ function mergeDeep<T extends { [key: string]: any }>(
 }
 
 const ConfBase: Partial<Configuration> = (() => {
-    return CONFIGURATIONS.DEFAULT;
+    return CONFIGURATIONS[config.apiBase];
 })();
 
 const Conf = mergeDeep<Configuration>(CONFIGURATIONS.DEFAULT, ConfBase);

--- a/src/config.example.ts
+++ b/src/config.example.ts
@@ -13,6 +13,12 @@ const config = {
     // You can check it using browser devtools, in the Network -> WS tab
     wsGateway: "wss://engame.mahjongsoul.com/gateway",
 
+    // Modes to be reviewed, eg. 4p south: [16, 12, 9], 3p east & south: [26, 25, 24, 23, 22, 21]
+    reviewModes: [16, 12, 9],
+
+    // Base Configuration of amae-koromo, "DEFAULT" for 4p, "ikeda" for 3p
+    apiBase: "DEFAULT",
+
     // Store your access token here
     // get it by logging into your temporary account and running the following command in the browser console:
     // GameMgr.Inst.access_token

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ class Record {
         this.index = GameRecord.getRankIndexByPlayer(rec, id);
     }
 }
-const reviewCompatibleModes = [16, 12, 9] as GameMode[];
+const reviewCompatibleModes = config.reviewModes as GameMode[];
 
 const loadLogIds = async (id: string, limit = 100) => {
     const loader = new PlayerDataLoader(


### PR DESCRIPTION
This PR adds options in config.ts which enables users selecting specific modes to review or use another amae-koromo api base (for 3-player games), as mentioned in #2 .